### PR TITLE
Fixed odd 'two lists that are used as one' functionality and am using…

### DIFF
--- a/04_Questions_ArraysAndStrings/CheckPermutation.cs
+++ b/04_Questions_ArraysAndStrings/CheckPermutation.cs
@@ -14,25 +14,25 @@ namespace _04_Questions_ArraysAndStrings
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
-            AddDataPair (new string[] { "",       "" },       true);
-            AddDataPair (new string[] { "a",      "1" },      false);
-            AddDataPair (new string[] { "apple",  "apple" },  true);
-            AddDataPair (new string[] { "apple",  "zapple" }, false);
-            AddDataPair (new string[] { "apples", "zapple" }, false);
-            AddDataPair (new string[] { "haa",    "aha" },    true);
-            AddDataPair (new string[] { "haa",    "aah" },    true);
+            AddTestRun (new string[] { "",       "" },       true);
+            AddTestRun (new string[] { "a",      "1" },      false);
+            AddTestRun (new string[] { "apple",  "apple" },  true);
+            AddTestRun (new string[] { "apple",  "zapple" }, false);
+            AddTestRun (new string[] { "apples", "zapple" }, false);
+            AddTestRun (new string[] { "haa",    "aha" },    true);
+            AddTestRun (new string[] { "haa",    "aah" },    true);
         }
 
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(string[] runData)
+        protected override void StateTest(string[] runData)
         {
             Console.WriteLine ("- Are chars of [" + runData[0] + "] a permutation of [" + runData[1] + "]");
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override bool RunStep(string[] runData)
+        protected override bool RunTest(string[] runData)
         {
             return IsPermutation (runData[0], runData[1]);
         }

--- a/04_Questions_ArraysAndStrings/IsUnique.cs
+++ b/04_Questions_ArraysAndStrings/IsUnique.cs
@@ -15,16 +15,16 @@ namespace _04_Questions_ArraysAndStrings
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
-            AddDataPair ("Fu-Bar".ToCharArray (),   true);
-            AddDataPair ("Foo-Bar".ToCharArray (),  false);
-            AddDataPair ("Fu-Barr".ToCharArray (),  false);
-            AddDataPair ("FFu-Barr".ToCharArray (), false);
+            AddTestRun ("Fu-Bar".ToCharArray (),   true);
+            AddTestRun ("Foo-Bar".ToCharArray (),  false);
+            AddTestRun ("Fu-Barr".ToCharArray (),  false);
+            AddTestRun ("FFu-Barr".ToCharArray (), false);
         }
 
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(char[] runData)
+        protected override void StateTest(char[] runData)
         {
             StringBuilder builder = new StringBuilder ();
             builder.Append ("                             [");
@@ -37,7 +37,7 @@ namespace _04_Questions_ArraysAndStrings
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override bool RunStep(char[] runData)
+        protected override bool RunTest(char[] runData)
         {
             return IsStrUnique (runData);
             //return IsCharAraUniqueUsingSort (runData);

--- a/04_Questions_ArraysAndStrings/OneAway.cs
+++ b/04_Questions_ArraysAndStrings/OneAway.cs
@@ -15,37 +15,37 @@ namespace _04_Questions_ArraysAndStrings
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
-            AddDataPair (new string[] { "",  "" },  true);
-            AddDataPair (new string[] { "a", "" },  true);
-            AddDataPair (new string[] { "a", "r" }, true);
+            AddTestRun (new string[] { "",  "" },  true);
+            AddTestRun (new string[] { "a", "" },  true);
+            AddTestRun (new string[] { "a", "r" }, true);
 
-            AddDataPair (new string[] { "toot",    "tooooot" }, false);
-            AddDataPair (new string[] { "tooooot", "toot" },    false);
-            AddDataPair (new string[] { "ReversE", "EsreveR" }, false);
+            AddTestRun (new string[] { "toot",    "tooooot" }, false);
+            AddTestRun (new string[] { "tooooot", "toot" },    false);
+            AddTestRun (new string[] { "ReversE", "EsreveR" }, false);
 
-            AddDataPair (new string[] { "Insert", "1Insert" }, true);
-            AddDataPair (new string[] { "Insert", "Ins2ert" }, true);
-            AddDataPair (new string[] { "Insert", "Insert3" }, true);
+            AddTestRun (new string[] { "Insert", "1Insert" }, true);
+            AddTestRun (new string[] { "Insert", "Ins2ert" }, true);
+            AddTestRun (new string[] { "Insert", "Insert3" }, true);
 
-            AddDataPair (new string[] { "Remove", "emove" }, true);
-            AddDataPair (new string[] { "Remove", "Remve" }, true);
-            AddDataPair (new string[] { "Remove", "Remov" }, true);
+            AddTestRun (new string[] { "Remove", "emove" }, true);
+            AddTestRun (new string[] { "Remove", "Remve" }, true);
+            AddTestRun (new string[] { "Remove", "Remov" }, true);
 
-            AddDataPair (new string[] { "Replace", "Zeplace" }, true);
-            AddDataPair (new string[] { "Replace", "Rep ace" }, true);
-            AddDataPair (new string[] { "Replace", "Replacc" }, true);
+            AddTestRun (new string[] { "Replace", "Zeplace" }, true);
+            AddTestRun (new string[] { "Replace", "Rep ace" }, true);
+            AddTestRun (new string[] { "Replace", "Replacc" }, true);
         }
 
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(string[] runData)
+        protected override void StateTest(string[] runData)
         {
             Console.WriteLine ("- Are [" + runData[0] + "] and [" + runData[1] + "] one or fewer edits different");
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override bool RunStep(string[] runData)
+        protected override bool RunTest(string[] runData)
         {
             return IsOneChangeAway (runData[0].ToCharArray (), runData[1].ToCharArray ());
         }

--- a/04_Questions_ArraysAndStrings/PalindromePermutation.cs
+++ b/04_Questions_ArraysAndStrings/PalindromePermutation.cs
@@ -15,20 +15,20 @@ namespace _04_Questions_ArraysAndStrings
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
-            AddDataPair ("hello",  false);
-            AddDataPair ("aabbcd", false);
-            AddDataPair ("abc",    false);
-            AddDataPair ("l",      true);
-            AddDataPair ("tacocat",      true);
-            AddDataPair ("$$##@@@@@",    true);
-            AddDataPair ("$$####@@@@@",  true);
-            AddDataPair ("$$#####@@@@@", false);
+            AddTestRun ("hello",  false);
+            AddTestRun ("aabbcd", false);
+            AddTestRun ("abc",    false);
+            AddTestRun ("l",      true);
+            AddTestRun ("tacocat",      true);
+            AddTestRun ("$$##@@@@@",    true);
+            AddTestRun ("$$####@@@@@",  true);
+            AddTestRun ("$$#####@@@@@", false);
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override bool RunStep(string runData)
+        protected override bool RunTest(string runData)
         {
             return IsPalindromePermutation (runData.ToCharArray ());
         }

--- a/04_Questions_ArraysAndStrings/Program.cs
+++ b/04_Questions_ArraysAndStrings/Program.cs
@@ -13,15 +13,15 @@ namespace _04_Questions_ArraysAndStrings
         {
             ProgramTools.SizeConsoleWindow ();
 
-            new IsUnique ().RunQuest ();
-            new CheckPermutation ().RunQuest ();
-            new URLify ().RunQuest ();
-            new PalindromePermutation ().RunQuest ();
-            new OneAway ().RunQuest ();
-            new StringCompression ().RunQuest ();
-            new RotateMatrix ().RunQuest ();
-            new ZeroMatrix ().RunQuest ();
-            new StringRotation ().RunQuest ();
+            new IsUnique ().BuildAndRunTests ();
+            new CheckPermutation ().BuildAndRunTests ();
+            new URLify ().BuildAndRunTests ();
+            new PalindromePermutation ().BuildAndRunTests ();
+            new OneAway ().BuildAndRunTests ();
+            new StringCompression ().BuildAndRunTests ();
+            new RotateMatrix ().BuildAndRunTests ();
+            new ZeroMatrix ().BuildAndRunTests ();
+            new StringRotation ().BuildAndRunTests ();
 
             ProgramTools.PauseForAnyKey ("Press any key to exit");
         }

--- a/04_Questions_ArraysAndStrings/RotateMatrix.cs
+++ b/04_Questions_ArraysAndStrings/RotateMatrix.cs
@@ -15,15 +15,15 @@ namespace _04_Questions_ArraysAndStrings
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
-            AddDataPair (MakeThreeMatrix (), MakeThreeMatrixResult ());
-            AddDataPair (MakeFourMatrix (),  MakeFourMatrixResult ());
-            AddDataPair (MakeFiveMatrix (),  MakeFiveMatrixResult ());
+            AddTestRun (MakeThreeMatrix (), MakeThreeMatrixResult ());
+            AddTestRun (MakeFourMatrix (),  MakeFourMatrixResult ());
+            AddTestRun (MakeFiveMatrix (),  MakeFiveMatrixResult ());
         }
 
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(int[][] runData)
+        protected override void StateTest(int[][] runData)
         {
             Console.WriteLine ("- Processing matrix:");
             Console.Write (ArrayTools.Stringify<int> (runData, "  "));
@@ -31,7 +31,7 @@ namespace _04_Questions_ArraysAndStrings
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override int[][] RunStep(int[][] runData)
+        protected override int[][] RunTest(int[][] runData)
         {
             Rotate (runData, true);
             return runData;

--- a/04_Questions_ArraysAndStrings/StringCompression.cs
+++ b/04_Questions_ArraysAndStrings/StringCompression.cs
@@ -17,17 +17,17 @@ namespace _04_Questions_ArraysAndStrings
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
-            AddDataPair ("",    "");
-            AddDataPair ("a",   "a");
-            AddDataPair ("sup", "sup");
-            AddDataPair ("ssssuup", "s4u2p1");
-            AddDataPair ("SsSsSsupppppppppppp", "S1s1S1s1S1s1u1p12");
+            AddTestRun ("",    "");
+            AddTestRun ("a",   "a");
+            AddTestRun ("sup", "sup");
+            AddTestRun ("ssssuup", "s4u2p1");
+            AddTestRun ("SsSsSsupppppppppppp", "S1s1S1s1S1s1u1p12");
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override string RunStep(string runData)
+        protected override string RunTest(string runData)
         {
             return GetCompressedString (runData);
         }

--- a/04_Questions_ArraysAndStrings/StringRotation.cs
+++ b/04_Questions_ArraysAndStrings/StringRotation.cs
@@ -16,27 +16,27 @@ namespace _04_Questions_ArraysAndStrings
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
-            AddDataPair (new string[] { "", "" }, true);
-            AddDataPair (new string[] { "HelloWorld", "lloWorldHe" }, true);
-            AddDataPair (new string[] { "hahahaha",   "hahahaha" },   true);
-            AddDataPair (new string[] { "Blah",       "ahBl" },       true);
+            AddTestRun (new string[] { "", "" }, true);
+            AddTestRun (new string[] { "HelloWorld", "lloWorldHe" }, true);
+            AddTestRun (new string[] { "hahahaha",   "hahahaha" },   true);
+            AddTestRun (new string[] { "Blah",       "ahBl" },       true);
 
-            AddDataPair (new string[] { "",  "a" }, false);
-            AddDataPair (new string[] { "a", "" },  false);
-            AddDataPair (new string[] { "hahaha",      "hahaah" },      false);
-            AddDataPair (new string[] { "HelloWorlds", "SHelloWorld" }, false);
+            AddTestRun (new string[] { "",  "a" }, false);
+            AddTestRun (new string[] { "a", "" },  false);
+            AddTestRun (new string[] { "hahaha",      "hahaah" },      false);
+            AddTestRun (new string[] { "HelloWorlds", "SHelloWorld" }, false);
         }
 
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(string[] runData)
+        protected override void StateTest(string[] runData)
         {
             Console.WriteLine ("- Are [" + runData[0] + "] and [" + runData[1] + "] single rotations of each other");
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override bool RunStep(string[] runData)
+        protected override bool RunTest(string[] runData)
         {
             return IsRotation (runData[0], runData[1]);
         }

--- a/04_Questions_ArraysAndStrings/URLify.cs
+++ b/04_Questions_ArraysAndStrings/URLify.cs
@@ -15,21 +15,21 @@ namespace _04_Questions_ArraysAndStrings
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
-            AddDataPair ("Hello World",   "Hello%20World");
-            AddDataPair (" HelloWorld  ", "%20HelloWorld%20%20");
-            AddDataPair ("Hello to the entire World", "Hello%20to%20the%20entire%20World");
+            AddTestRun ("Hello World",   "Hello%20World");
+            AddTestRun (" HelloWorld  ", "%20HelloWorld%20%20");
+            AddTestRun ("Hello to the entire World", "Hello%20to%20the%20entire%20World");
         }
 
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(string runData)
+        protected override void StateTest(string runData)
         {
             Console.WriteLine ("- Encoding spaces to '%20' in string [" + runData + "]");
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override string RunStep(string runData)
+        protected override string RunTest(string runData)
         {
             // Set up character array with additional space at the end
             char[] chara = new char[runData.Length * 2];

--- a/04_Questions_ArraysAndStrings/ZeroMatrix.cs
+++ b/04_Questions_ArraysAndStrings/ZeroMatrix.cs
@@ -15,16 +15,16 @@ namespace _04_Questions_ArraysAndStrings
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
-            AddDataPair (MakeExampleOne (),   MakeExampleOneResult ());
-            AddDataPair (MakeExampleTwo (),   MakeExampleTwoResult ());
-            AddDataPair (MakeExampleThree (), MakeExampleThreeResult ());
-            AddDataPair (MakeExampleFour (),  MakeExampleFourResult ());
+            AddTestRun (MakeExampleOne (),   MakeExampleOneResult ());
+            AddTestRun (MakeExampleTwo (),   MakeExampleTwoResult ());
+            AddTestRun (MakeExampleThree (), MakeExampleThreeResult ());
+            AddTestRun (MakeExampleFour (),  MakeExampleFourResult ());
         }
 
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(int[][] runData)
+        protected override void StateTest(int[][] runData)
         {
             Console.WriteLine ("- Processing matrix:");
             Console.Write (ArrayTools.Stringify<int> (runData, "  "));
@@ -32,7 +32,7 @@ namespace _04_Questions_ArraysAndStrings
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override int[][] RunStep(int[][] runData)
+        protected override int[][] RunTest(int[][] runData)
         {
             Zeroify (runData);
             return runData;

--- a/05_Questions_LinkedLists/DeleteMiddleNode.cs
+++ b/05_Questions_LinkedLists/DeleteMiddleNode.cs
@@ -16,21 +16,21 @@ namespace _05_Questions_LinkedLists
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
-            AddDataPair (new SingleLL (1, 2, 3), new SingleLL (1, 3));
-            AddDataPair (new SingleLL (1, 2, 3, 4), new SingleLL (1, 2, 4));
-            AddDataPair (new SingleLL (1, 2, 3, 4, 5), new SingleLL (1, 2, 4, 5));
+            AddTestRun (new SingleLL (1, 2, 3), new SingleLL (1, 3));
+            AddTestRun (new SingleLL (1, 2, 3, 4), new SingleLL (1, 2, 4));
+            AddTestRun (new SingleLL (1, 2, 3, 4, 5), new SingleLL (1, 2, 4, 5));
         }
 
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(SingleLL runData)
+        protected override void StateTest(SingleLL runData)
         {
             Console.WriteLine ("- Delete middle node from: [" + runData + "]");
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override SingleLL RunStep(SingleLL runData)
+        protected override SingleLL RunTest(SingleLL runData)
         {
             if (runData.GetLength () < 3)
             {

--- a/05_Questions_LinkedLists/Intersection.cs
+++ b/05_Questions_LinkedLists/Intersection.cs
@@ -16,7 +16,7 @@ namespace _05_Questions_LinkedLists
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
             ConciseAddDataPair (new int[] { },         new int[] { },            new int[] { });
             ConciseAddDataPair (new int[] { 1 },       new int[] { 10 },         new int[] { });
@@ -26,14 +26,28 @@ namespace _05_Questions_LinkedLists
             ConciseAddDataPair (new int[] { 1, 2 },    new int[] { 10, 11, 12 }, new int[] { 50 });
         }
 
+        // Shorthand for the verbose AddDataPair()
+        private void ConciseAddDataPair(int[] valsOne, int[] valsTwo, int[] endVals)
+        {
+            // Add the endVals list to the end of both valsOne and valsTwo
+            SingleLL endList = new SingleLL (endVals);
+            SingleLL listOne = new SingleLL (valsOne).AddLast (endList);
+            SingleLL listTwo = new SingleLL (valsTwo).AddLast (endList);
+
+            // The intersection point is the expected return value
+            // If endVals was empty then endList.root will be null, for the case of having no intersection
+            AddTestRun (new SingleLL[] { listOne, listTwo }, endList.root);
+        }
+
+
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(SingleLL[] runData)
+        protected override void StateTest(SingleLL[] runData)
         {
             Console.WriteLine ("- Check for intersection between: [" + runData[0] + "] and [" + runData[1] + "]");
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override SingleLL.Node RunStep(SingleLL[] runData)
+        protected override SingleLL.Node RunTest(SingleLL[] runData)
         {
             return FindIntersection (runData[0], runData[1]);
         }
@@ -76,17 +90,6 @@ namespace _05_Questions_LinkedLists
 
             // No intersection found
             return null;
-        }
-
-
-        // Shorthand for the verbose AddDataPair()
-        private void ConciseAddDataPair(int[] valsOne, int[] valsTwo, int[] endVals)
-        {
-            SingleLL endList = new SingleLL (endVals);
-            SingleLL listOne = new SingleLL (valsOne).AddLast (endList);
-            SingleLL listTwo = new SingleLL (valsTwo).AddLast (endList);
-
-            AddDataPair (new SingleLL[] { listOne, listTwo }, endList.root);
         }
 
     }

--- a/05_Questions_LinkedLists/LoopDetection.cs
+++ b/05_Questions_LinkedLists/LoopDetection.cs
@@ -15,19 +15,26 @@ namespace _05_Questions_LinkedLists
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
-            AddDataPair (new SingleLL (), false);
+            AddTestRun (new SingleLL (), false);
+        }
+        
+        // Shorthand for the verbose AddDataPair()
+        private void ConciseAddDataPair(int[] valsStart, int[] valsLoop, bool expectedResult)
+        {
+            
         }
 
+
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(SingleLL runData)
+        protected override void StateTest(SingleLL runData)
         {
             Console.WriteLine ("- Finding if loop exists in: [" + runData + "]");
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override bool RunStep(SingleLL runData)
+        protected override bool RunTest(SingleLL runData)
         {
             return HasLoop (runData);
         }

--- a/05_Questions_LinkedLists/Palindrome.cs
+++ b/05_Questions_LinkedLists/Palindrome.cs
@@ -14,28 +14,28 @@ namespace _05_Questions_LinkedLists
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
-            AddDataPair (new SingleLL (1),             true);
-            AddDataPair (new SingleLL (1, 2, 1),       true);
-            AddDataPair (new SingleLL (1, 2, 2, 1),    true);
-            AddDataPair (new SingleLL (1, 2, 1, 2, 1), true);
+            AddTestRun (new SingleLL (1),             true);
+            AddTestRun (new SingleLL (1, 2, 1),       true);
+            AddTestRun (new SingleLL (1, 2, 2, 1),    true);
+            AddTestRun (new SingleLL (1, 2, 1, 2, 1), true);
 
-            AddDataPair (new SingleLL (),                 false);
-            AddDataPair (new SingleLL (1, 2),             false);
-            AddDataPair (new SingleLL (1, 2, 2),          false);
-            AddDataPair (new SingleLL (2, 2, 2, 1),       false);
-            AddDataPair (new SingleLL (1, 2, 1, 2, 1, 2), false);
+            AddTestRun (new SingleLL (),                 false);
+            AddTestRun (new SingleLL (1, 2),             false);
+            AddTestRun (new SingleLL (1, 2, 2),          false);
+            AddTestRun (new SingleLL (2, 2, 2, 1),       false);
+            AddTestRun (new SingleLL (1, 2, 1, 2, 1, 2), false);
         }
 
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(SingleLL runData)
+        protected override void StateTest(SingleLL runData)
         {
             Console.WriteLine ("- Is palindrome: [" + runData + "]");
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override bool RunStep(SingleLL runData)
+        protected override bool RunTest(SingleLL runData)
         {
             return IsPalindrome (runData);
         }

--- a/05_Questions_LinkedLists/Partition.cs
+++ b/05_Questions_LinkedLists/Partition.cs
@@ -34,7 +34,7 @@ namespace _05_Questions_LinkedLists
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
             ConciseAddDataPair (5, ArrayTools.RandomInt (10, 0, 10));
             ConciseAddDataPair (5, ArrayTools.RandomInt (10, 5, 10));
@@ -43,14 +43,21 @@ namespace _05_Questions_LinkedLists
             ConciseAddDataPair (5);
         }
 
+        // Shorthand for the verbose AddDataPair()
+        private void ConciseAddDataPair(int partVal, params int[] theVals)
+        {
+            AddTestRun (new PartitionData (partVal, new SingleLL (theVals)), null);
+        }
+
+
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(PartitionData runData)
+        protected override void StateTest(PartitionData runData)
         {
             Console.WriteLine ("- Patrition on value " + runData.partValue + " for set: [" + runData.list + "]");
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override PartitionData RunStep(PartitionData runData)
+        protected override PartitionData RunTest(PartitionData runData)
         {
             PartitionList (runData.partValue, runData.list);
             return new PartitionData (runData.partValue, runData.list);
@@ -120,13 +127,6 @@ namespace _05_Questions_LinkedLists
                 lowLead.next = highRoot;
             else
                 list.root = highRoot;
-        }
-
-
-        // Shorthand for the verbose AddDataPair()
-        private void ConciseAddDataPair(int partVal, params int[] theVals)
-        {
-            AddDataPair (new PartitionData (partVal, new SingleLL (theVals)), null);
         }
 
     }

--- a/05_Questions_LinkedLists/Program.cs
+++ b/05_Questions_LinkedLists/Program.cs
@@ -12,14 +12,14 @@ namespace _05_Questions_LinkedLists
         {
             ProgramTools.SizeConsoleWindow ();
 
-            //new RemoveDupes ().RunQuest ();
-            //new ReturnKthToLast ().RunQuest ();
-            //new DeleteMiddleNode ().RunQuest ();
-            //new Partition ().RunQuest ();
-            //new SumListsReverse ().RunQuest ();
-            //new SumLists ().RunQuest ();
-            //new Palindrome ().RunQuest ();
-            new Intersection ().RunQuest ();
+            new RemoveDupes ().BuildAndRunTests ();
+            new ReturnKthToLast ().BuildAndRunTests ();
+            new DeleteMiddleNode ().BuildAndRunTests ();
+            new Partition ().BuildAndRunTests ();
+            new SumListsReverse ().BuildAndRunTests ();
+            new SumLists ().BuildAndRunTests ();
+            new Palindrome ().BuildAndRunTests ();
+            new Intersection ().BuildAndRunTests ();
             //new LoopDetection ().RunQuest ();
 
             ProgramTools.PauseForAnyKey ("Press any key to exit");

--- a/05_Questions_LinkedLists/RemoveDupes.cs
+++ b/05_Questions_LinkedLists/RemoveDupes.cs
@@ -16,24 +16,24 @@ namespace _05_Questions_LinkedLists
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
-            AddDataPair (new SingleLL (), new SingleLL ());
-            AddDataPair (new SingleLL (1, 2, 3, 4, 5), new SingleLL (1, 2, 3, 4, 5));
-            AddDataPair (new SingleLL (1, 2, 1, 4, 5), new SingleLL (1, 2, 4, 5));
-            AddDataPair (new SingleLL (1, 1, 1, 1), new SingleLL (1));
-            AddDataPair (new SingleLL (1, 2, 3, 1, 2, 3), new SingleLL (1, 2, 3));
-            AddDataPair (new SingleLL (5, 4, 3, 3, 3, 1, 2, 5, 5), new SingleLL (5, 4, 3, 1, 2));
+            AddTestRun (new SingleLL (), new SingleLL ());
+            AddTestRun (new SingleLL (1, 2, 3, 4, 5), new SingleLL (1, 2, 3, 4, 5));
+            AddTestRun (new SingleLL (1, 2, 1, 4, 5), new SingleLL (1, 2, 4, 5));
+            AddTestRun (new SingleLL (1, 1, 1, 1), new SingleLL (1));
+            AddTestRun (new SingleLL (1, 2, 3, 1, 2, 3), new SingleLL (1, 2, 3));
+            AddTestRun (new SingleLL (5, 4, 3, 3, 3, 1, 2, 5, 5), new SingleLL (5, 4, 3, 1, 2));
         }
 
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(SingleLL runData)
+        protected override void StateTest(SingleLL runData)
         {
             Console.WriteLine ("- Removing duplicate values from: [" + runData + "]");
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override SingleLL RunStep(SingleLL runData)
+        protected override SingleLL RunTest(SingleLL runData)
         {
             RemoveDuplicatesWithBuffer (runData);
             return runData;

--- a/05_Questions_LinkedLists/ReturnKthToLast.cs
+++ b/05_Questions_LinkedLists/ReturnKthToLast.cs
@@ -15,21 +15,21 @@ namespace _05_Questions_LinkedLists
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
-            AddDataPair (new SingleLL (0, 1, 2, 3), 0);
-            AddDataPair (new SingleLL (0, 1, 2, 3, 4, 5), 2);
-            AddDataPair (new SingleLL (0, 1, 2), -1);
+            AddTestRun (new SingleLL (0, 1, 2, 3), 0);
+            AddTestRun (new SingleLL (0, 1, 2, 3, 4, 5), 2);
+            AddTestRun (new SingleLL (0, 1, 2), -1);
         }
 
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(SingleLL runData)
+        protected override void StateTest(SingleLL runData)
         {
             Console.WriteLine ("- Find 3rd from last value in: [" + runData + "]");
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override int RunStep(SingleLL runData)
+        protected override int RunTest(SingleLL runData)
         {
             try
             {

--- a/05_Questions_LinkedLists/SumLists.cs
+++ b/05_Questions_LinkedLists/SumLists.cs
@@ -16,7 +16,7 @@ namespace _05_Questions_LinkedLists
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
             ConciseAddDataPair (0,   0);
             ConciseAddDataPair (10,  0);
@@ -24,14 +24,21 @@ namespace _05_Questions_LinkedLists
             ConciseAddDataPair (503, 29);
         }
 
+        // Shorthand for the verbose AddDataPair()
+        private void ConciseAddDataPair(int numOne, int numTwo)
+        {
+            AddTestRun (new SingleLL[] { MakeNum (numOne), MakeNum (numTwo) }, MakeNum (numOne + numTwo));
+        }
+
+
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(SingleLL[] runData)
+        protected override void StateTest(SingleLL[] runData)
         {
             Console.WriteLine ("- Adding: [" + runData[0] + "] + [" + runData[1] + "]");
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override SingleLL RunStep(SingleLL[] runData)
+        protected override SingleLL RunTest(SingleLL[] runData)
         {
             return Sum (runData[0], runData[1]);
         }
@@ -78,13 +85,7 @@ namespace _05_Questions_LinkedLists
             result.AddFirst (sum % 10);
             return sum > 9;
         }
-
-
-        // Shorthand for the verbose AddDataPair()
-        private void ConciseAddDataPair(int numOne, int numTwo)
-        {
-            AddDataPair (new SingleLL[] { MakeNum (numOne), MakeNum (numTwo) }, MakeNum (numOne + numTwo));
-        }
+        
 
         private static SingleLL MakeNum(int number)
         {

--- a/05_Questions_LinkedLists/SumListsReverse.cs
+++ b/05_Questions_LinkedLists/SumListsReverse.cs
@@ -16,7 +16,7 @@ namespace _05_Questions_LinkedLists
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
             ConciseAddDataPair (0,   0);
             ConciseAddDataPair (10,  0);
@@ -24,14 +24,21 @@ namespace _05_Questions_LinkedLists
             ConciseAddDataPair (503, 29);
         }
 
+        // Shorthand for the verbose AddDataPair()
+        private void ConciseAddDataPair(int numOne, int numTwo)
+        {
+            AddTestRun (new SingleLL[] { MakeNum (numOne), MakeNum (numTwo) }, MakeNum (numOne + numTwo));
+        }
+
+
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(SingleLL[] runData)
+        protected override void StateTest(SingleLL[] runData)
         {
             Console.WriteLine ("- Adding: [" + runData[0] + "] + [" + runData[1] + "]");
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override SingleLL RunStep(SingleLL[] runData)
+        protected override SingleLL RunTest(SingleLL[] runData)
         {
             return Sum (runData[0], runData[1]);
         }
@@ -67,13 +74,7 @@ namespace _05_Questions_LinkedLists
 
             return result;
         }
-
-
-        // Shorthand for the verbose AddDataPair()
-        private void ConciseAddDataPair(int numOne, int numTwo)
-        {
-            AddDataPair (new SingleLL[] { MakeNum (numOne), MakeNum (numTwo) }, MakeNum (numOne + numTwo));
-        }
+        
 
         private static SingleLL MakeNum(int number)
         {

--- a/Helpers/QuestBlank.cs
+++ b/Helpers/QuestBlank.cs
@@ -12,19 +12,19 @@ namespace Helpers
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
-            AddDataPair (null, null);
+            AddTestRun (null, null);
         }
 
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(object runData)
+        protected override void StateTest(object runData)
         {
             Console.WriteLine ("- Processing: [" + runData + "]");
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override object RunStep(object runData)
+        protected override object RunTest(object runData)
         {
             return null;
         }

--- a/Helpers/QuestBlankSmall.cs
+++ b/Helpers/QuestBlankSmall.cs
@@ -12,19 +12,19 @@ namespace Helpers
 
 
         // Build lists that determine RunStep() data and each of their expected results.
-        protected override void BuildDatas()
+        protected override void BuildTestRuns()
         {
-            AddDataPair (null, null);
+            AddTestRun (null, null);
         }
 
         // Write description of this particular RunStep(), namely to identify the current runData.
-        protected override void StateGoals(object runData)
+        protected override void StateTest(object runData)
         {
             Console.WriteLine ("- Processing: [" + runData + "]");
         }
 
         // Use runData to perform desired operation and return the result.
-        protected override object RunStep(object runData)
+        protected override object RunTest(object runData)
         {
             return null;
         }


### PR DESCRIPTION
… TestRun class now instead. Switched naming of several methods to reflect name change weirdness from 'data pair' and 'data' to TestRun-related, much clearer. Moved order of Quest around some to better match related methods together